### PR TITLE
Terraform+ansible

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,5 +1,5 @@
 ---
-- name: Insatll Docker, Docker-compose
+- name: Install Docker, Docker Compose
   hosts: docker_server
   become: yes
   tasks:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,48 @@
+---
+- name: Insatll Docker, Docker-compose
+  hosts: docker_server
+  become: yes
+  tasks:
+    - name: Install Docker
+      yum:
+        name: docker
+        update_cache: true
+        state: present
+    - name: Install docker-compose
+      get_url:
+        url: https://github.com/docker/compose/releases/download/1.27.4/docker-compose-Linux-{{lookup('pipe', 'uname -m')}}
+        dest: /usr/local/bin/docker-compose
+        mode: +x
+    - name: Start docker daemon
+      systemd:
+        name: docker
+        state: started
+    - name: Install docker python module
+      pip:
+        name:
+          - docker
+          - docker-compose
+
+- name: add ec2-user to docker group
+  hosts: docker_server
+  become: yes
+  tasks:
+    - name: add ec2-user to docker group
+      user:
+        name: ec2-user
+        groups: docker
+        append: yes
+    - name: reconnect to server session
+      meta: reset_connection
+
+- name: start docker containers
+  hosts: docker_server
+  tasks:
+    - name: copy docker compose
+      copy:
+        src: /home/sonali-rajput/Projects/ansible/docker-compose.yml
+        dest: /home/ec2-user/docker-compose.yml
+    - name: start container
+      docker_compose:
+        project_src: /home/ec2-user
+        state: present

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,6 +44,6 @@ resource "aws_instance" "vm" {
   }
 
 provisioner "local-exec" {
-  command = "echo [docker_server] > ..\\ansible\\inventory.ini && echo ${self.public_ip} ansible_user=ec2-user ansible_ssh_private_key_file=~/.ssh/id_rsa >> ..\\ansible\\inventory.ini"
+  command = "echo [docker_server] > ..\\ansible\\inventory.ini && echo ${self.public_ip} ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/id_rsa >> ..\\ansible\\inventory.ini"
 }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,49 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "default"
+}
+
+resource "aws_key_pair" "deployer" {
+  key_name   = "terraform-key"
+  public_key = file(var.public_key_path)
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_security_group" "ssh_access" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound traffic"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "vm" {
+  ami                    = "ami-084568db4383264d4"
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.deployer.key_name
+  associate_public_ip_address = true
+  vpc_security_group_ids = [aws_security_group.ssh_access.id]
+
+  tags = {
+    Name = "team-it-works-on-my-machine"
+  }
+
+provisioner "local-exec" {
+  command = "echo [docker_server] > ..\\ansible\\inventory.ini && echo ${self.public_ip} ansible_user=ec2-user ansible_ssh_private_key_file=~/.ssh/id_rsa >> ..\\ansible\\inventory.ini"
+}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "public_ip" {
+  value = aws_instance.vm.public_ip
+  description = "Public IP of the EC2 instance"
+}

--- a/terraform/setup.md
+++ b/terraform/setup.md
@@ -1,7 +1,7 @@
 1> Launch AWS Academy Learner Lab and    AWS CLI:   
    Copy and paste the following into ~/.aws/credentials
 
-2> create a terraform.tfvars file arcodding to the terraform.tfvars.example (enter the public key path)
+2> create a terraform.tfvars file according to the terraform.tfvars.example (enter the public key path)
 
 3> run terraform init
 

--- a/terraform/setup.md
+++ b/terraform/setup.md
@@ -1,0 +1,8 @@
+1> Launch AWS Academy Learner Lab and    AWS CLI:   
+   Copy and paste the following into ~/.aws/credentials
+
+2> create a terraform.tfvars file arcodding to the terraform.tfvars.example (enter the public key path)
+
+3> run terraform init
+
+4> run terraform apply

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable "public_key_path" {
+  description = "Path to your SSH public key file"
+}


### PR DESCRIPTION
close #34 

This pull request introduces infrastructure automation using Terraform and Ansible to deploy and configure a Docker environment on an AWS EC2 instance. The most important changes include adding Terraform configurations to provision AWS resources, creating an Ansible playbook for Docker installation and setup, and defining output variables and documentation for deployment.

### Terraform Configuration Changes:
* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R1-R49): Added Terraform configuration to provision an AWS EC2 instance, set up SSH access using a security group, and define a key pair for authentication. Included a local-exec provisioner to generate an inventory file for Ansible.
* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R1-R3): Defined a variable `public_key_path` to specify the path to the SSH public key file.
* [`terraform/outputs.tf`](diffhunk://#diff-39c11374cc25633f69e49ef1485fa8d4dfd4c33cde3027c8c20a2b84346ebf7cR1-R4): Added an output variable to expose the public IP of the EC2 instance for external access.

### Ansible Playbook Changes:
* [`ansible/playbook.yml`](diffhunk://#diff-f5b0294ee7c07af1b2c6802c443dbd18a6c861061bb590a28e0f5b22d856c456R1-R48): Created an Ansible playbook to install Docker, Docker Compose, and related Python modules, add the `ec2-user` to the Docker group, and start Docker containers using a provided `docker-compose.yml` file.

### Documentation Updates:
* [`terraform/setup.md`](diffhunk://#diff-11b51a551bf109fc98c661de59d2a5804c64cf255f44720ad05c936a81d3880dR1-R8): Added step-by-step instructions for setting up AWS credentials, creating a `terraform.tfvars` file, initializing Terraform, and applying the configuration.