### PR TITLE
ports are now baked into the image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,15 +4,13 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile
-      args:
-        - CLIENT_PORT=${CLIENT_PORT}
     environment:
         - ASSET_DIR=/usr/share/nginx/html
         - APP_PREFIX=PREFIX_
         - PREFIX_GH_CONNECTOR_URL=${GH_CONNECTOR_URL}
         - PREFIX_GH_OAUTH_CLIENT_ID=${GH_OAUTH_CLIENT_ID}
     ports:
-      - "${CLIENT_PORT}:${CLIENT_PORT}"
+      - "${CLIENT_PORT}:80"
     depends_on:
      - gh-connector
     restart: unless-stopped
@@ -22,10 +20,8 @@ services:
     build:
       context: ./gh-connector
       dockerfile: Dockerfile
-      args:
-        - GH_CONNECTOR_PORT=${GH_CONNECTOR_PORT}
     ports:
-      - "${GH_CONNECTOR_PORT}:${GH_CONNECTOR_PORT}"
+      - "${GH_CONNECTOR_PORT}:3000"
     environment:
       - CLIENT_URL=${CLIENT_URL}
       # Since we call container -> container we use the internal hostname
@@ -39,13 +35,10 @@ services:
     build:
       context: ./genai
       dockerfile: Dockerfile
-      args:
-        - GENAI_PORT=${GENAI_PORT}
     ports:
-      - "${GENAI_PORT}:${GENAI_PORT}"
+      - "${GENAI_PORT}:3001"
     environment:
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
-      - GENAI_PORT=${GENAI_PORT}
       - GENAI_URL=${GENAI_URL}
     restart: unless-stopped
 
@@ -54,10 +47,8 @@ services:
     build:
       context: ./users
       dockerfile: Dockerfile
-      args:
-        - USERS_PORT=${USERS_PORT}
     ports:
-      - "${USERS_PORT}:${USERS_PORT}"
+      - "${USERS_PORT}:3002"
     depends_on:
       - users-db
     environment:

--- a/genai/Dockerfile
+++ b/genai/Dockerfile
@@ -1,8 +1,6 @@
 # Use Python 3.9 slim as the base image
 FROM python:3.9-slim
 
-ARG GENAI_PORT=3001
-
 # Set the working directory to /app
 WORKDIR /app
 
@@ -16,7 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Expose port
-EXPOSE ${GENAI_PORT}
+EXPOSE 3001
 
 # Start the FastAPI app with uvicorn
 CMD ["python", "app/main.py"]

--- a/genai/app/main.py
+++ b/genai/app/main.py
@@ -31,8 +31,14 @@ async def ask_question(payload: dict = Body(...)):
     response = chain.invoke({"question": question})
     return {"response": response.content}
 
+@app.get("/ping")
+async def ping():
+    return "Pong from GenAI Service"
+
+
+
 
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run("main:app", host="0.0.0.0", port=int(os.getenv('GENAI_PORT')), reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=int(3001), reload=True)

--- a/gh-connector/Dockerfile
+++ b/gh-connector/Dockerfile
@@ -8,8 +8,7 @@ RUN gradle bootJar --no-daemon
 
 # Stage 2: Run the application
 FROM gcr.io/distroless/java21-debian12
-ARG GH_CONNECTOR_PORT=3000
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-EXPOSE ${GH_CONNECTOR_PORT}
+EXPOSE 3000
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/gh-connector/src/main/java/de/tum/gh_connector/controller/GhConnectorController.java
+++ b/gh-connector/src/main/java/de/tum/gh_connector/controller/GhConnectorController.java
@@ -22,7 +22,6 @@ import de.tum.gh_connector.dto.ContentResponseItem;
 import de.tum.gh_connector.dto.GenAIAskResponse;
 import jakarta.servlet.http.HttpSession;
 
-
 @RestController
 public class GhConnectorController {
 
@@ -34,7 +33,7 @@ public class GhConnectorController {
 
     @Value("${genai.url}")
     private String genaiUrl;
-    
+
     @Value("${client.url}")
     private String clientUrl;
 
@@ -66,10 +65,11 @@ public class GhConnectorController {
         String tokenType = (String) tokenResponse.get("token_type");
 
         if (accessToken == null || tokenType == null) {
-            return ResponseEntity.badRequest().body("Invalid token response from GitHub. " + tokenResponse.entrySet().stream()
-                    .map(entry -> entry.getKey() + ": " + entry.getValue())
-                    .reduce((a, b) -> a + ", " + b)
-                    .orElse(""));
+            return ResponseEntity.badRequest()
+                    .body("Invalid token response from GitHub. " + tokenResponse.entrySet().stream()
+                            .map(entry -> entry.getKey() + ": " + entry.getValue())
+                            .reduce((a, b) -> a + ", " + b)
+                            .orElse(""));
         }
 
         // ✅ Step 2: Store access token and user info in session
@@ -139,13 +139,14 @@ public class GhConnectorController {
                 .toEntity(new ParameterizedTypeReference<>() {
                 });
 
-
-
         // Querry GenAI Service
-        String files = repoContents.getBody().stream().map(ContentResponseItem::getPath).collect(Collectors.joining(", "));
+        String files = repoContents.getBody().stream().map(ContentResponseItem::getPath)
+                .collect(Collectors.joining(", "));
 
         Map<String, Object> genAIRequest = new HashMap<>();
-        genAIRequest.put("question", "Guess what this code project could be about based on these filenames from the root directory. But write only one sentence: " + files);
+        genAIRequest.put("question",
+                "Guess what this code project could be about based on these filenames from the root directory. But write only one sentence: "
+                        + files);
 
         WebClient webClient = WebClient.create(genaiUrl);
 
@@ -163,7 +164,7 @@ public class GhConnectorController {
 
     @GetMapping(value = "/ping")
     public String ping() {
-        return "Pong\n";
+        return "Pong from GH-Connector\n";
     }
 
 }

--- a/gh-connector/src/main/resources/application.properties
+++ b/gh-connector/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=gh-connector
-server.port=${GH_CONNECTOR_PORT:3000}
+server.port=3000
 server.servlet.contextPath=${GH_CONNECTOR_PREFIX:/}
 
 

--- a/users/Dockerfile
+++ b/users/Dockerfile
@@ -8,8 +8,7 @@ RUN gradle bootJar --no-daemon
 
 # Stage 2: Run the application
 FROM gcr.io/distroless/java21-debian12
-ARG USERS_PORT=3002
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-EXPOSE ${USERS_PORT:-3002}
+EXPOSE 3002
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/users/src/main/java/de/tum/users/controller/UserController.java
+++ b/users/src/main/java/de/tum/users/controller/UserController.java
@@ -31,7 +31,8 @@ public class UserController {
     @GetMapping("/users/{username}")
     public User getUser(@PathVariable String username) {
         return userRepository.findByUsername(username)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found with username: " + username));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "User not found with username: " + username));
     }
 
     @PostMapping("/users")
@@ -40,12 +41,16 @@ public class UserController {
         return userRepository.save(user);
     }
 
-
     @DeleteMapping("/users/{username}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteUser(@PathVariable String username) {
         User user = userRepository.findByUsername(username)
-            .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new RuntimeException("User not found"));
         userRepository.delete(user);
+    }
+
+    @GetMapping(value = "/ping")
+    public String ping() {
+        return "Pong from User Service\n";
     }
 }

--- a/users/src/main/resources/application.properties
+++ b/users/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=users
-server.port=8590
+server.port=3002
 spring.datasource.url: jdbc:postgresql://${USERS_DB_HOST:localhost}:5432/users
 spring.datasource.username=${USERS_DB_USERNAME:postgres}
 spring.datasource.password=${USERS_DB_PASSWORD:123456}


### PR DESCRIPTION
The changes Felix and I talked about on the train:

Ports of services are now constant - But the different container runtimes (kubernetes and compose) can still be used to map the ports at runtime. The values are pulled from the .env file.

Every service now has a "/ping" endpoint for testing
