### PR TITLE
Use lf for .sh files since otherwise autocrlf will convert them to CRLF and cause issues when running inside docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
I tried to run `docker compose up --build` today and the client did not start because the `env.sh` file was using crlf instead of lf. This PR fixes this by telling git to use lf for *.sh files