### PR TITLE
Add new install app button to frontend

### DIFF
--- a/client/src/components/page/landing-page.tsx
+++ b/client/src/components/page/landing-page.tsx
@@ -50,6 +50,23 @@ function Login() {
   )
 }
 
+function InstallApp() {
+  function handleInstall() {
+    console.log('install')
+    // Open the GitHub App installation page in a new tab
+    const installUrl = `https://github.com/apps/devops-workflowgenie-2025/installations/select_target`
+    window.open(installUrl, '_blank', 'noopener,noreferrer')
+  }
+  return (
+    <Button
+      className="px-6 py-2 bg-secondary text-secondary-foreground rounded-lg shadow hover:bg-secondary/80"
+      onClick={handleInstall}
+    >
+      Install App on GitHub
+    </Button>
+  )
+}
+
 function LandingPage() {
   const [repoUrl, setRepoUrl] = useState('')
   const [error, setError] = useState(false)
@@ -135,6 +152,7 @@ function LandingPage() {
           ) : (
             <Login />
           )}
+          {isLoggedIn && <InstallApp />}
         </div>
         {data && <Profile user={data as UserType} />}
       </div>


### PR DESCRIPTION
Since we are using GitHub Apps, we need to install the App on the users account to be be able to read their private repositories. For this a new button in the frontend was added that is only displayed when the user is logged in. 