### PR TITLE
Add alerts configuration file for Prometheus

### DIFF
--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -3,6 +3,7 @@ from prom/prometheus:latest
 EXPOSE 9090
 
 COPY prometheus.k8s.yml /etc/prometheus/prometheus.yml
+COPY alerts.yml /etc/prometheus/alerts.yml
 
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD [ "-config.file=/etc/prometheus/prometheus.yml", \


### PR DESCRIPTION
This pull request adds functionality to the Prometheus Docker setup by including a new configuration file for alerts.

Configuration updates:

* [`prometheus/Dockerfile`](diffhunk://#diff-769c1ae3cbfeba8d7a35982226533d74adbe093b79bbb0c2423dc0dd5285b033R6): Added a new `alerts.yml` file to the Prometheus Docker image, enabling alerting configurations to be included alongside the primary Prometheus configuration file.